### PR TITLE
[+] Added the change rep-rating button for admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 *.log
 *.db
 .env
+*.DS_Store

--- a/src/admin_handlers/admin_handlers.py
+++ b/src/admin_handlers/admin_handlers.py
@@ -1,5 +1,6 @@
 from admin_main_menu import admin_main_menu_handlers
 from change_public_id import admin_change_public_id_handlers
+from change_rep_rating import admin_change_rep_rating_handlers
 from open_registration import admin_open_registration_handlers
 from close_registration import admin_close_registration_handlers
 from show_registered import admin_show_registered_handlers
@@ -13,6 +14,7 @@ from delete_admin import admin_delete_admin_handlers
 
 admin_callback_handlers = admin_main_menu_handlers + \
 admin_change_public_id_handlers + \
+admin_change_rep_rating_handlers + \
 admin_open_registration_handlers + \
 admin_close_registration_handlers + \
 admin_show_registered_handlers + \

--- a/src/admin_handlers/admin_main_menu.py
+++ b/src/admin_handlers/admin_main_menu.py
@@ -13,6 +13,7 @@ admin_inline_keyboard = InlineKeyboardMarkup([
     [InlineKeyboardButton("Закрыть регистрацию на турнир", callback_data="admin_close_registration")],
     [InlineKeyboardButton("Показать список участников", callback_data="admin_show_registered")],
     [InlineKeyboardButton("Изменить ID игрока", callback_data="admin_change_public_id")],
+    [InlineKeyboardButton("Изменить rep-рейтинг игрока", callback_data="admin_change_rep_rating")],
     [InlineKeyboardButton("Добавить пост в расписание", callback_data="admin_update_timetable")],
     [InlineKeyboardButton("Удалить пост из расписания", callback_data="admin_delete_timetable")],
     [InlineKeyboardButton("Добавить пост для лагеря", callback_data="admin_add_camp")],

--- a/src/admin_handlers/change_public_id.py
+++ b/src/admin_handlers/change_public_id.py
@@ -5,7 +5,7 @@ from databaseAPI import rep_chess_db
 
 
 async def process_changing_public_id(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    rep_ids = update.message.text.split(" ")
+    rep_ids = update.message.text.split()
     if len(rep_ids) != 2:
         await update.message.reply_text("Прочитай формат ещё раз")
         await admin_change_public_id(update, context)

--- a/src/admin_handlers/change_rep_rating.py
+++ b/src/admin_handlers/change_rep_rating.py
@@ -1,0 +1,66 @@
+from telegram import Update
+from telegram.ext import CallbackQueryHandler, ContextTypes
+
+from databaseAPI import rep_chess_db
+
+
+async def process_changing_rep_rating(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    input_parts = update.message.text.split()
+
+    if len(input_parts) != 2:
+        await send_error_and_prompt(update, context, error_text="Формат ввода неверный, попробуйте еще раз")
+        return
+    
+    public_id, rep_rating = input_parts
+
+    if not rep_rating.isdigit() or not public_id.isdigit():
+        await send_error_and_prompt(update, context, error_text="Не похоже что ID и рейтинг введены верно.")
+        return
+    
+    try:
+        public_id = int(public_id)
+        rep_rating = int(rep_rating)
+    except ValueError:
+        await send_error_and_prompt(update, context, error_text="Неверный формат чисел, попробуй еще раз.")
+        return
+
+    if rep_rating >= 3000:
+        await send_error_and_prompt(update, context, error_text="Вы уверены, что рейтинг игрока выше 3000?")
+        return
+
+    # rating of 100 is possible elo
+    if rep_rating < 100:
+        await send_error_and_prompt(update, context, error_text="Рейтинг игрока ниже 100, все настолько плохо...?")
+        return
+    
+    context.user_data["text_state"] = None
+
+    # send database query and check for ID's existence 
+    try:
+        rep_chess_db.update_user_rep_rating_with_rep_id(public_id, rep_rating)
+        await update.message.reply_text("Рейтинг игрока обновлен.")
+    except ValueError as err:
+        await send_error_and_prompt(update, context, error_text="Игрока с таким rep ID не существует, не удалось обновить рейтинг.")
+
+
+async def admin_change_rep_rating(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    query = update.callback_query
+    if query:
+        await query.answer()
+
+    context.user_data["text_state"] = process_changing_rep_rating
+    message = await context.bot.send_message(
+        update.effective_chat.id,
+        "Введите сначала rep ID и после новый rep рейтинг игрока через пробел:",
+    )
+
+
+admin_change_rep_rating_handlers = [
+    CallbackQueryHandler(admin_change_rep_rating, pattern="^admin_change_rep_rating$")
+]
+
+
+# for DRY purposes
+async def send_error_and_prompt(update, context, error_text):
+    msg = await update.message.reply_text(error_text)
+    await admin_change_rep_rating(update, context)

--- a/src/databaseAPI.py
+++ b/src/databaseAPI.py
@@ -5,7 +5,6 @@ import os
 import sys
 from collections import deque
 
-
 logger = logging.getLogger(__name__)
 logfile_dir = os.getenv("REPCHESS_LOG_DIR")
 logger_handler = logging.FileHandler(os.path.join(logfile_dir, "database.log"))
@@ -260,13 +259,23 @@ class RepChessDB:
             )
         logger.debug(f"update chesscom_rating {telegram_id=}, {chesscom_rating=}")
 
-    def update_user_rep_rating(self, telegram_id: int, rep_rating: int):
+    def update_user_rep_rating_with_rep_id(self, public_id: int, rep_rating: int):
+        with self.conn:
+            cursour = self.conn.execute(
+                """UPDATE user SET rep_rating = ?, last_contact = ? WHERE public_id = ?""",
+                (rep_rating, datetime.datetime.now(), public_id)
+            )
+        if cursour.rowcount == 0:
+            raise ValueError(f"User with public_id {public_id} not found in the database")
+        logger.debug(f"update rep rating {public_id=}, {rep_rating=}")
+    
+    def update_user_rep_rating_with_user_id(self, user_id: int, rep_rating: int):
         with self.conn:
             self.conn.execute(
-                """UPDATE user SET rep_rating = ?, last_contact = ? WHERE telegram_id = ?""",
-                (rep_rating, datetime.datetime.now(), telegram_id)
+                """UPDATE user SET rep_rating = ?, last_contact = ? WHERE user_id = ?""",
+                (rep_rating, datetime.datetime.now(), user_id)
             )
-        logger.debug(f"update rep rating {telegram_id=}, {rep_rating=}")
+        logger.debug(f"update rep rating {user_id=}, {rep_rating=}")
 
     def update_user_last_contact(self, telegram_id: int):
         with self.conn:


### PR DESCRIPTION
Решение этого [issue](https://github.com/deadule/chessbot/issues/7)
- Добавлена кнопка редактирования реп-рейтинга для админа
- Функция обновления реп-рейтинга в БД разделена на обновление по public_id и по user_id

Имеется опция лишь редактирования рейтинга, добавление нового игрока не предусмотрено, нужно подумать над способом внесения изменений из гугл таблицы, возможно стоит:
- Сделать никнеймы эксклюзивными и добавить опцию изменения рейтинга по ним для удобства админов
- Автоматизировать процесс изменения рейтинга с помощью перевода гугл-таблицы в формат .csv и его считывания